### PR TITLE
Initial SVG parsing logic.

### DIFF
--- a/dev/tools/svg2dart/lib/svg2dart.dart
+++ b/dev/tools/svg2dart/lib/svg2dart.dart
@@ -20,20 +20,20 @@ import 'package:xml/xml.dart' hide parse;
 /// support SVG files exported by a specific tool the motion design team is
 /// using.
 FrameData interpretSvg(String svgFilePath) {
-  File file = new File(svgFilePath);
+  final File file = new File(svgFilePath);
   if (!file.existsSync()) {
     throw new ArgumentError('$file does not exist');
   }
-  String fileData = file.readAsStringSync();
+  final String fileData = file.readAsStringSync();
   final XmlElement svgElement = _extractSvgElement(xml.parse(fileData));
-  double width = parsePixels(_extractAttr(svgElement, 'width')).toDouble();
-  double height = parsePixels(_extractAttr(svgElement, 'height')).toDouble();
+  final double width = parsePixels(_extractAttr(svgElement, 'width')).toDouble();
+  final double height = parsePixels(_extractAttr(svgElement, 'height')).toDouble();
 
-  List<SvgPath> paths = <SvgPath>[];
+  final List<SvgPath> paths = <SvgPath>[];
   for (XmlNode child in svgElement.children) {
     if (child.nodeType != XmlNodeType.ELEMENT)
       continue;
-    XmlElement childElement = child;
+    final XmlElement childElement = child;
 
     // TODO(amirh): recrusively parse groups and apply transforms
     if (childElement.name.local == 'path') {
@@ -56,10 +56,10 @@ final RegExp _pointMatcher = new RegExp(r' *([\-\.0-9]+) *, *([\-\.0-9]+)(.*)');
 /// [Point(25.0, 1.0), Point(12.0, 12.0), Point(23.0, 9.0)].
 List<Point<double>> parsePoints(String points) {
   String unParsed = points;
-  List<Point<double>> result = [];
+  final List<Point<double>> result = <Point<double>>[];
   while(unParsed.isNotEmpty && _pointMatcher.hasMatch(unParsed)) {
-    Match m = _pointMatcher.firstMatch(unParsed);
-    result.add(new Point(
+    final Match m = _pointMatcher.firstMatch(unParsed);
+    result.add(new Point<double>(
         double.parse(m.group(1)),
         double.parse(m.group(2))
     ));
@@ -105,12 +105,12 @@ class SvgPath {
 
   static SvgPath fromElement(XmlElement pathElement) {
     assert(pathElement.name.local == 'path');
-    String id = _extractAttr(pathElement, 'id');
-    String dAttr = _extractAttr(pathElement, 'd');
-    List<SvgPathCommand> commands = <SvgPathCommand> [];
+    final String id = _extractAttr(pathElement, 'id');
+    final String dAttr = _extractAttr(pathElement, 'd');
+    final List<SvgPathCommand> commands = <SvgPathCommand> [];
     for (Match match in _pathCommandMatcher.allMatches(dAttr)) {
-      String commandType = match.group(1);
-      String pointStr = match.group(2);
+      final String commandType = match.group(1);
+      final String pointStr = match.group(2);
       commands.add(new SvgPathCommand(commandType, parsePoints(pointStr)));
     }
     return new SvgPath(id, commands);
@@ -189,19 +189,19 @@ int parsePixels(String pixels) {
 
 String _extractAttr(XmlElement element, String name) {
   try {
-    return element.attributes.singleWhere((x) => x.name.local == name)
+    return element.attributes.singleWhere((XmlAttribute x) => x.name.local == name)
         .value;
   } catch (e) {
     throw new ArgumentError(
         'Can\'t find a single \'$name\' attributes in ${element.name}, '
-        + 'attributes were: ${element.attributes}'
+        'attributes were: ${element.attributes}'
     );
   }
 }
 
 XmlElement _extractSvgElement(XmlDocument document) {
   return document.children.singleWhere(
-          (node) => node.nodeType  == XmlNodeType.ELEMENT
+          (XmlNode node) => node.nodeType  == XmlNodeType.ELEMENT
           && _asElement(node).name.local == 'svg'
   );
 }

--- a/dev/tools/svg2dart/lib/svg2dart.dart
+++ b/dev/tools/svg2dart/lib/svg2dart.dart
@@ -1,0 +1,204 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+import 'dart:math';
+
+import 'package:collection/collection.dart';
+import 'package:xml/xml.dart' as xml show parse;
+import 'package:xml/xml.dart' hide parse;
+
+/// Interprets an SVG file.
+///
+/// Recursively goes over the SVG tree, applying transforms and opacities,
+/// and build a FrameData which is a flat representation of the paths in the SVG
+/// file, after applying transformations and converting relative coordinates to
+/// absolute.
+FrameData interpretSvg(String svgFilePath) {
+  File file = new File(svgFilePath);
+  if (!file.existsSync()) {
+    throw new ArgumentError('$file does not exist');
+  }
+  String fileData = file.readAsStringSync();
+  final XmlElement svgElement = _extractSvgElement(xml.parse(fileData));
+  double width = parsePixels(_extractAttr(svgElement, 'width')).toDouble();
+  double height = parsePixels(_extractAttr(svgElement, 'height')).toDouble();
+
+  List<SvgPath> paths = <SvgPath>[];
+  for (XmlNode child in svgElement.children) {
+    if (child.nodeType != XmlNodeType.ELEMENT)
+      continue;
+    XmlElement childElement = child;
+
+    // TODO(amirh): recrusively parse groups and apply transforms
+    if (childElement.name.local == 'path') {
+      paths.add(SvgPath.fromElement(childElement));
+    }
+  }
+  return new FrameData(new Point<double>(width, height), paths);
+}
+
+// Given a points list in the form e.g: "25.0, 1.0 12.0, 12.0 23.0, 9.0" matches
+// the coordinated of the first point and the rest of the string, for the
+// example above:
+// group 1 will match "25.0"
+// group 2 will match "1.0"
+// group 3 will match "12.0, 12.0 23.0, 9.0"
+final RegExp _pointMatcher = new RegExp(r' *([\-\.0-9]+) *, *([\-\.0-9]+)(.*)');
+
+/// Parse a string with a list of points, e.g:
+/// '25.0, 1.0 12.0, 12.0 23.0, 9.0' will be parsed to:
+/// [Point(25.0, 1.0), Point(12.0, 12.0), Point(23.0, 9.0)].
+List<Point<double>> parsePoints(String points) {
+  String unParsed = points;
+  List<Point<double>> result = [];
+  while(unParsed.isNotEmpty && _pointMatcher.hasMatch(unParsed)) {
+    Match m = _pointMatcher.firstMatch(unParsed);
+    result.add(new Point(
+        double.parse(m.group(1)),
+        double.parse(m.group(2))
+    ));
+    unParsed = m.group(3);
+  }
+  return result;
+}
+
+/// Data for a single animation frame.
+class FrameData {
+  const FrameData(this.size, this.paths);
+
+  final Point<double> size;
+  final List<SvgPath> paths;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+          other is FrameData &&
+              runtimeType == other.runtimeType &&
+              size == other.size &&
+              const ListEquality<SvgPath>().equals(paths, other.paths);
+
+  @override
+  int get hashCode =>
+      size.hashCode ^
+      paths.hashCode;
+
+  @override
+  String toString() {
+    return 'FrameData{size: $size, paths: $paths}';
+  }
+}
+
+/// Represents an SVG path element.
+class SvgPath {
+  const SvgPath(this.id, this.commands);
+
+  final String id;
+  final List<SvgPathCommand> commands;
+
+  static final RegExp _pathCommandMatcher = new RegExp(r'([MmLlQqCcAZz]) *([\-\.0-9 ,]*)');
+
+  static SvgPath fromElement(XmlElement pathElement) {
+    assert(pathElement.name.local == 'path');
+    String id = _extractAttr(pathElement, 'id');
+    String dAttr = _extractAttr(pathElement, 'd');
+    List<SvgPathCommand> commands = <SvgPathCommand> [];
+    for (Match match in _pathCommandMatcher.allMatches(dAttr)) {
+      String commandType = match.group(1);
+      String pointStr = match.group(2);
+      commands.add(new SvgPathCommand(commandType, parsePoints(pointStr)));
+    }
+    return new SvgPath(id, commands);
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+          other is SvgPath &&
+              runtimeType == other.runtimeType &&
+              id == other.id &&
+              const ListEquality<SvgPathCommand>().equals(commands, other.commands);
+
+  @override
+  int get hashCode =>
+      id.hashCode ^
+      commands.hashCode;
+
+  @override
+  String toString() {
+    return 'SvgPath{id: $id, commands: $commands}';
+  }
+}
+
+/// Represents a single SVG path command from an SVG d element.
+///
+/// This class normalizes all the 'd' commands into a single type, that has
+/// a command type and a list of points.
+///
+/// Some examples of how d commands translated to SvgPathCommand:
+///   * "M 0.0, 1.0" => SvgPathCommand('M', [Point(0.0, 1.0)])
+///   * "Z" => SvgPathCommand('Z', [])
+///   * "C 1.0, 1.0 2.0, 2.0 3.0, 3.0" SvgPathCommand('C', [Point(1.0, 1.0),
+///      Point(2.0, 2.0), Point(3.0, 3.0)])
+class SvgPathCommand {
+  const SvgPathCommand(this.type, this.points);
+
+  /// The command type.
+  final String type;
+
+  /// List of points used by this command.
+  final List<Point<double>> points;
+
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+          other is SvgPathCommand &&
+              runtimeType == other.runtimeType &&
+              type == other.type &&
+              const ListEquality<Point<double>>().equals(points, other.points);
+
+  @override
+  int get hashCode =>
+      type.hashCode ^
+      points.hashCode;
+
+  @override
+  String toString() {
+    return 'SvgPathCommand{command: $type, points: $points}';
+  }
+}
+
+// Matches a pixels expression e.g "14px".
+// First group is just the number.
+final RegExp _pixelsExp = new RegExp('^([0-9]+)px\$');
+
+/// Parses a pixel expression, e.g "14px", and returns the number.
+/// Throws an [ArgumentError] if the given string doesn't match the pattern.
+int parsePixels(String pixels) {
+  if (!_pixelsExp.hasMatch(pixels))
+    throw new ArgumentError('illegal pixels expression: \'$pixels\'');
+  return int.parse(_pixelsExp.firstMatch(pixels).group(1));
+}
+
+String _extractAttr(XmlElement element, String name) {
+  try {
+    return element.attributes.singleWhere((x) => x.name.local == name)
+        .value;
+  } catch (e) {
+    throw new ArgumentError(
+        'Can\'t find a single \'$name\' attributes in ${element.name}, '
+        + 'attributes were: ${element.attributes}'
+    );
+  }
+}
+
+XmlElement _extractSvgElement(XmlDocument document) {
+  return document.children.singleWhere(
+          (node) => node.nodeType  == XmlNodeType.ELEMENT
+          && _asElement(node).name.local == 'svg'
+  );
+}
+
+XmlElement _asElement(XmlNode node) => node;

--- a/dev/tools/svg2dart/lib/svg2dart.dart
+++ b/dev/tools/svg2dart/lib/svg2dart.dart
@@ -9,12 +9,16 @@ import 'package:collection/collection.dart';
 import 'package:xml/xml.dart' as xml show parse;
 import 'package:xml/xml.dart' hide parse;
 
-/// Interprets an SVG file.
+/// Interprets some subset of an SVG* file.
 ///
 /// Recursively goes over the SVG tree, applying transforms and opacities,
 /// and build a FrameData which is a flat representation of the paths in the SVG
 /// file, after applying transformations and converting relative coordinates to
 /// absolute.
+///
+/// * Note that this does not support the SVG specification, but is just built to
+/// support SVG files exported by a specific tool the motion design team is
+/// using.
 FrameData interpretSvg(String svgFilePath) {
   File file = new File(svgFilePath);
   if (!file.existsSync()) {
@@ -114,11 +118,12 @@ class SvgPath {
 
   @override
   bool operator ==(Object other) =>
-      identical(this, other) ||
+      identical(this, other) || (
           other is SvgPath &&
-              runtimeType == other.runtimeType &&
-              id == other.id &&
-              const ListEquality<SvgPathCommand>().equals(commands, other.commands);
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          const ListEquality<SvgPathCommand>().equals(commands, other.commands)
+      );
 
   @override
   int get hashCode =>
@@ -127,7 +132,7 @@ class SvgPath {
 
   @override
   String toString() {
-    return 'SvgPath{id: $id, commands: $commands}';
+    return 'SvgPath(id: $id, commands: $commands)';
   }
 }
 

--- a/dev/tools/svg2dart/pubspec.yaml
+++ b/dev/tools/svg2dart/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 
 dependencies:
   args: ^1.2.0
+  xml: ^2.6.0
 
 dev_dependencies:
   test: ^0.12.0

--- a/dev/tools/svg2dart/test/svg2dart_test.dart
+++ b/dev/tools/svg2dart/test/svg2dart_test.dart
@@ -56,14 +56,14 @@ void main() {
     });
 
     test('horizontal bar', () {
-      FrameData frameData = interpretSvg(testAsset('horizontal_bar.svg'));
-      expect(frameData.paths, [
+      final FrameData frameData = interpretSvg(testAsset('horizontal_bar.svg'));
+      expect(frameData.paths, <SvgPath>[
         const SvgPath('path_1', const<SvgPathCommand> [
-          const SvgPathCommand('M', const [const Point<double>(0.0, 19.0)]),
-          const SvgPathCommand('L', const [const Point<double>(48.0, 19.0)]),
-          const SvgPathCommand('L', const [const Point<double>(48.0, 29.0)]),
-          const SvgPathCommand('L', const [const Point<double>(0.0, 29.0)]),
-          const SvgPathCommand('Z', const []),
+          const SvgPathCommand('M', const <Point<double>> [const Point<double>(0.0, 19.0)]),
+          const SvgPathCommand('L', const <Point<double>> [const Point<double>(48.0, 19.0)]),
+          const SvgPathCommand('L', const <Point<double>> [const Point<double>(48.0, 29.0)]),
+          const SvgPathCommand('L', const <Point<double>> [const Point<double>(0.0, 29.0)]),
+          const SvgPathCommand('Z', const <Point<double>> []),
         ]),
       ]);
     });

--- a/dev/tools/svg2dart/test/svg2dart_test.dart
+++ b/dev/tools/svg2dart/test/svg2dart_test.dart
@@ -1,0 +1,76 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:math';
+
+import 'package:svg2dart/svg2dart.dart';
+import 'package:test/test.dart';
+import 'package:path/path.dart' as path;
+
+const String kPackagePath = '.';
+
+void main() {
+
+  test('parsePixels', () {
+    expect(parsePixels('23px'), 23);
+    expect(parsePixels('9px'), 9);
+    expect(() { parsePixels('9pt'); }, throwsA(const isInstanceOf<ArgumentError>()));
+  });
+
+  test('parsePoints', () {
+    expect(parsePoints('1.0, 2.0'),
+        const <Point<double>> [const Point<double>(1.0, 2.0)]
+    );
+    expect(parsePoints('12.0, 34.0 5.0, 6.6'),
+        const <Point<double>> [
+          const Point<double>(12.0, 34.0),
+          const Point<double>(5.0, 6.6),
+        ]
+    );
+  });
+
+  group('parseSvg', () {
+    test('empty SVGs', () {
+      interpretSvg(testAsset('empty_svg_1_48x48.svg'));
+      interpretSvg(testAsset('empty_svg_2_100x50.svg'));
+    });
+
+    test('illegal SVGs', () {
+      expect(
+        () { interpretSvg(testAsset('illegal_svg_multiple_roots.svg')); },
+        throwsA(anything)
+      );
+    });
+
+    test('SVG size', () {
+      expect(
+          interpretSvg(testAsset('empty_svg_1_48x48.svg')).size,
+          const Point<double>(48.0, 48.0)
+      );
+
+      expect(
+          interpretSvg(testAsset('empty_svg_2_100x50.svg')).size,
+          const Point<double>(100.0, 50.0)
+      );
+    });
+
+    test('horizontal bar', () {
+      FrameData frameData = interpretSvg(testAsset('horizontal_bar.svg'));
+      expect(frameData.paths, [
+        const SvgPath('path_1', const<SvgPathCommand> [
+          const SvgPathCommand('M', const [const Point<double>(0.0, 19.0)]),
+          const SvgPathCommand('L', const [const Point<double>(48.0, 19.0)]),
+          const SvgPathCommand('L', const [const Point<double>(48.0, 29.0)]),
+          const SvgPathCommand('L', const [const Point<double>(0.0, 29.0)]),
+          const SvgPathCommand('Z', const []),
+        ]),
+      ]);
+    });
+  });
+}
+
+String testAsset(String name) {
+  return path.join(kPackagePath, 'test_assets', name);
+}
+

--- a/dev/tools/svg2dart/test_assets/empty_svg_1_48x48.svg
+++ b/dev/tools/svg2dart/test_assets/empty_svg_1_48x48.svg
@@ -1,0 +1,2 @@
+<svg id="svg_build_00" xmlns="http://www.w3.org/2000/svg" width="48px" height="48px" >
+</svg>

--- a/dev/tools/svg2dart/test_assets/empty_svg_2_100x50.svg
+++ b/dev/tools/svg2dart/test_assets/empty_svg_2_100x50.svg
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Empty SVG file -->
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    id="empty_svg"
    width="100px"

--- a/dev/tools/svg2dart/test_assets/empty_svg_2_100x50.svg
+++ b/dev/tools/svg2dart/test_assets/empty_svg_2_100x50.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Empty SVG file -->
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="empty_svg"
+   width="100px"
+   height="50px">
+</svg>

--- a/dev/tools/svg2dart/test_assets/horizontal_bar.svg
+++ b/dev/tools/svg2dart/test_assets/horizontal_bar.svg
@@ -1,0 +1,3 @@
+<svg id="svg_build_00" xmlns="http://www.w3.org/2000/svg" width="48px" height="48px" >
+<path id="path_1" d="M 0,19.0 L 48.0, 19.0 L 48.0, 29.0 L 0, 29.0 Z " fill="#000000" />
+</svg>

--- a/dev/tools/svg2dart/test_assets/illegal_svg_multiple_roots.svg
+++ b/dev/tools/svg2dart/test_assets/illegal_svg_multiple_roots.svg
@@ -1,0 +1,4 @@
+<svg id="svg_build_00" xmlns="http://www.w3.org/2000/svg" width="48px" height="48px" >
+</svg>
+<svg id="svg_build_01" xmlns="http://www.w3.org/2000/svg" width="48px" height="48px" >
+</svg>

--- a/dev/tools/svg2dart/test_assets/illegal_svg_multiple_roots.svg
+++ b/dev/tools/svg2dart/test_assets/illegal_svg_multiple_roots.svg
@@ -1,4 +1,3 @@
 <svg id="svg_build_00" xmlns="http://www.w3.org/2000/svg" width="48px" height="48px" >
 </svg>
-<svg id="svg_build_01" xmlns="http://www.w3.org/2000/svg" width="48px" height="48px" >
-</svg>
+<svg/>


### PR DESCRIPTION
To keep a reasonable CL size there are still missing parts:
  * The interpreter does not traverse the entire the SVG tree yet, just the
    first level.
  * Transforms and opacities are not yet applied.
  * Relative coordinates are not yet converted to absolute.

Tracking bug: https://github.com/flutter/flutter/issues/13345